### PR TITLE
Revert "bdi: Do not use freezable workqueue"

### DIFF
--- a/mm/backing-dev.c
+++ b/mm/backing-dev.c
@@ -247,8 +247,8 @@ static int __init default_bdi_init(void)
 {
 	int err;
 
-	bdi_wq = alloc_workqueue("writeback", WQ_MEM_RECLAIM | WQ_UNBOUND |
-				 WQ_SYSFS, 0);
+	bdi_wq = alloc_workqueue("writeback", WQ_MEM_RECLAIM | WQ_FREEZABLE |
+					      WQ_UNBOUND | WQ_SYSFS, 0);
 	if (!bdi_wq)
 		return -ENOMEM;
 


### PR DESCRIPTION
All credits go to freak07!

This reverts commit c801b7e6784c67bb2d7d5f4ba0c81d53cbbf1465.

Subsequent to 7b74d84a306fd9692512916f15a3672d2dbf810a ("Merge 4.14.240 into android-4.14-stable"), this patch causes
devices to randomly freeze on downstream kernels. This happens mostly during
suspend. Force restarting the device via button combination leaves no ramoops or logs.