### PR TITLE
arm64: dts: sunfish: Enable ULPS when display is idle

### DIFF
--- a/arch/arm64/boot/dts/google/sm7150-sunfish-display.dtsi
+++ b/arch/arm64/boot/dts/google/sm7150-sunfish-display.dtsi
@@ -94,6 +94,7 @@
 	qcom,mdss-dsi-t-clk-pre = <0x33>;
 	qcom,platform-te-gpio = <&tlmm 10 0>;
 	qcom,platform-reset-gpio = <&pm6150l_gpios 9 0>;
+ 	qcom,ulps-enabled;
 	qcom,mdss-dsi-display-timings {
 		timing@0{
 			qcom,mdss-dsi-panel-phy-timings = [00 21 08 08 25 22 09
@@ -111,6 +112,7 @@
 	qcom,mdss-dsi-t-clk-pre = <0x36>;
 	qcom,platform-te-gpio = <&tlmm 10 0>;
 	qcom,platform-reset-gpio = <&pm6150l_gpios 9 0>;
+ 	qcom,ulps-enabled;
 	qcom,mdss-dsi-display-timings {
 		timing@0{
 			qcom,mdss-dsi-panel-phy-timings = [00 24 09 0A 26 24 09


### PR DESCRIPTION
The original commit was: https://github.com/kerneltoast/android_kernel_google_floral/commit/3fd7c888ac3e2ad01678bfe299012b8ea602d6fd

I simply applied it to our device.

"This saves power when there is a static image on the display." sultanxda