### PR TITLE
ARM: dts: msm: Change the FD clock to 400Mhz for SVS

### DIFF
--- a/arch/arm64/boot/dts/qcom/sdmmagpie-camera.dtsi
+++ b/arch/arm64/boot/dts/qcom/sdmmagpie-camera.dtsi
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018-2019, The Linux Foundation. All rights reserved.
+ * Copyright (c) 2018-2019, 2021 The Linux Foundation. All rights reserved.
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 and
@@ -994,7 +994,7 @@
 		clock-cntl-level = "lowsvs", "svs", "svs_l1", "turbo";
 		clock-rates =
 			<380000000 0 0>,
-			<384000000 0 0>,
+			<400000000 0 0>,
 			<480000000 0 0>,
 			<600000000 0 0>;
 		status = "ok";


### PR DESCRIPTION
Change FD hw SVS clock to 400Mhz as per the hardware team
recommendation. This change helping to resolve the FD
reset issue and process the fd requests.

Change-Id: Icdd4569472e176b54d7df50eebbf037354bb4225
Signed-off-by: Ravikishore Pampana <rpampana@codeaurora.org>

This follows-up [this commit](https://github.com/fsociety-tribute/sunfish_archive/commit/db07f715a2ae7da3f6771d00eb20dbe0d08b84e9) that got merged with the Android 12 update.